### PR TITLE
Change mongo Id validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ const _hapiQueryBuilderHandler = async (requestQuery, defaultLimit) => {
     const searchQuery = await searchQueryHandler(dollarQuery);
 
     for (const item in requestQuery) {
-      if (Mongoose.Types.ObjectId.isValid(requestQuery[item])) {
+      if (Mongoose.Types.ObjectId.isValid(requestQuery[item]) && requestQuery[item].length === 24) {
         requestQuery[item] = Mongoose.Types.ObjectId(requestQuery[item]);
       } else {
         requestQuery[item] = strToNumber(requestQuery[item]);


### PR DESCRIPTION
Check is getting failed. Any string 12-24 character treated as mongo id. Now we have added another check for length. Although it's not a perfect solution but can work